### PR TITLE
ToolsExample only worked for "C:\Users\Alexandre\Documents\GitHub\OpenNlp\Resources\..."

### DIFF
--- a/ToolsExample/App.config
+++ b/ToolsExample/App.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="MaximumEntropyModelDirectory" value="C:\Users\Alexandre\Documents\GitHub\OpenNlp\Resources\Models\"/>
-    <add key="WordnetSearchDirectory" value="C:\Users\Alexandre\Documents\GitHub\OpenNLP\Resources\WordNet\dict\"/>
+    <add key="MaximumEntropyModelDirectory" value="Resources\Models\"/>
+    <add key="WordnetSearchDirectory" value="Resources\WordNet\dict\"/>
   </appSettings>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>

--- a/ToolsExample/ToolsExample.csproj
+++ b/ToolsExample/ToolsExample.csproj
@@ -116,10 +116,10 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PreBuildEvent>
-    </PreBuildEvent>
-    <PostBuildEvent>
-    </PostBuildEvent>
-  </PropertyGroup>
+  <Target Name="AfterBuild">
+    <CreateItem Include="..\Resources\**\*.*">
+      <Output TaskParameter="Include" ItemName="Resources" />
+    </CreateItem>
+    <Copy SourceFiles="@(Resources)" DestinationFolder="$(OutputPath)Resources\%(RecursiveDir)" SkipUnchangedFiles="true" />
+  </Target>
 </Project>


### PR DESCRIPTION
Now it works in any machine. ;)

I just instruct `msbuild` to copy the resource folder into the output folder and take it from there.