### PR TITLE
Shallow copy from TokenizationRules to tokenizationRules

### DIFF
--- a/OpenNLP/Tools/Tokenize/EnglishRuleBasedTokenizer.cs
+++ b/OpenNLP/Tools/Tokenize/EnglishRuleBasedTokenizer.cs
@@ -25,7 +25,7 @@ namespace OpenNLP.Tools.Tokenize
         /// <param name="splitOnHyphen">Wether words with hyphens should be tokenized.</param>
         public EnglishRuleBasedTokenizer(bool splitOnHyphen)
         {
-            var tokenizationRules = TokenizationRules;
+            var tokenizationRules = new List<string>(TokenizationRules);
             if (splitOnHyphen)
             {
                 tokenizationRules.AddRange(HyphenSpecificTokenizationRules);


### PR DESCRIPTION
Since TokenizationRules is a static list of string, every time I new an EnglishRuleBasedTokenizer(splitOnHyphen=true), it will execute TokenizationRules.AddRange(HyphenSpecificTokenizationRules), which means that there will be more and more regexes in TokenizationRules. As a result, if I new an EnglishRuleBasedTokenizer every time I want to tokenize a text, the execution time will become longer.